### PR TITLE
Replace wc_checkout_params with woocommerce_params

### DIFF
--- a/samedaycourier-shipping.php
+++ b/samedaycourier-shipping.php
@@ -594,7 +594,7 @@ function custom_checkout_script() {
         const doAjaxCall = function (params) {
             $.ajax({
                 'type': 'POST',
-                'url': wc_checkout_params.ajax_url,
+                'url': woocommerce_params.ajax_url,
                 'data': params,
                 success: function () {
                     $(document.body).trigger('update_checkout');


### PR DESCRIPTION
Since creating the doAjaxCall function this is available on all pages. The problem is that wc_checkout_params is available only on checkout page, so it always display an error(wc_checkout_params undefined)